### PR TITLE
fix broken link to view demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <p>An app to help you chat in secret</p>
 
   <p align="center">
-    <a href="https://github.com/Dun-sin/Whisper/issues/new?assignees=&labels=bug&template=bug_report.md&title=">View Demo</a>
+    <a href="https://whischat.vercel.app/">View Demo</a>
     ·
     <a href="https://github.com/Dun-sin/Whisper/issues/new?assignees=&labels=bug&template=bug.yml&title=%5BBUG%5D+%3Cdescription%3E">Report Bug</a>
     ·


### PR DESCRIPTION
## 🛠️ Fixes Issue

On top of readme the VIEW DEMO link was broken

## 👨‍💻 Changes proposed

added link forwarding to https://whischat.vercel.app/

## ✔️ Check List (Check all the applicable boxes) 

[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done


- [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

