### PR TITLE
feat: cancel editing on ESC key press

### DIFF
--- a/client/src/components/Chat.jsx
+++ b/client/src/components/Chat.jsx
@@ -258,6 +258,23 @@ const Chat = () => {
             .timeout(10000)
             .emit('typing', { chatId: currentChatId, isTyping: false });
     };
+    
+    // Clear chat when escape is pressed
+    useEffect(() => {
+        const keyDownHandler = event => {
+
+            if (event.key === 'Escape' && editing.isediting) {
+                event.preventDefault();
+                cancelEdit();
+            };
+        }
+
+        document.addEventListener('keydown', keyDownHandler);
+
+        return () => {
+            document.removeEventListener('keydown', keyDownHandler);
+        };
+    }, [editing]);
 
     const handleTypingStatus = debounce((e) => {
         if (e.target.value.length > 0) {


### PR DESCRIPTION
# Fixes Issue

**My PR closes #189**

# 👨‍💻 Changes proposed(What did you do ?)
Added a useEffect hook that adds an event listener for the `Escape` key and cancels editing.
# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots

<!-- Add all the screenshots which support your changes -->
