### PR TITLE
fix: added spacing to navbar icons

### DIFF
--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -29,7 +29,7 @@ const NavBar = () => {
         <div
             className="navContainer bg-secondary md:w-[120px] md:min-h-[100vh] mdl: flex items-center flex-col mdl:flex-row justify-center shadow-[0_0_100px_0_rgba(0,0,0,1)] p-5"
         >
-            <div className="justify-between flex items-center flex-col mdl:flex-row h-[35%] w-[100%]">
+            <div className="justify-between flex items-center flex-col mdl:flex-row h-[35%] w-[100%] gap-3">
                 <NavLink
                     to="/"
                     className={({ isActive }) =>


### PR DESCRIPTION
# Fixes Issue

**My PR closes #191  **

# 👨‍💻 Changes proposed(What did you do ?)
- Added a gap-3 to the nav bar items. Even if they are highlighted they still look separated now.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots

<!-- Add all the screenshots which support your changes -->
<img width="90" alt="Screenshot 2022-10-22 at 15 50 43" src="https://user-images.githubusercontent.com/53917461/197342721-e3f641b9-ea98-4602-b781-5c9976a5e02e.png">
<img width="95" alt="Screenshot 2022-10-22 at 15 50 36" src="https://user-images.githubusercontent.com/53917461/197342723-37dc685e-c106-4dda-998b-634ab923bcfa.png">
