### PR TITLE
feat: added button to stop searching for a buddy

### DIFF
--- a/client/src/components/BuddyMatcher.jsx
+++ b/client/src/components/BuddyMatcher.jsx
@@ -5,7 +5,7 @@ import { SocketContext } from 'context/Context';
 import Anonymous from 'components/Anonymous';
 import { useAuth } from 'src/context/AuthContext';
 import { useChat } from 'src/context/ChatContext';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { useNotification } from 'src/lib/notification';
 
 const BuddyMatcher = () => {
@@ -136,6 +136,14 @@ const BuddyMatcher = () => {
         <div className="flex w-full justify-center items-center min-h-[86.5vh] flex-col bg-primary">
             <ThreeDots fill="rgb(255 159 28)" />
             <div className="text-lg text-center text-white">{loadingText}</div>
+            <Link
+                to="/"
+                className={
+                    'hover:no-underline hover:text-white font-medium text-white text-[1.5em] w-[8em] h-[2.3em] mt-4 rounded-[30px] border-4 border-solid border-[#f04336] flex flex-col items-center justify-center'
+                }
+            >
+                Stop
+            </Link>
         </div>
     );
 };


### PR DESCRIPTION
# Fixes Issue

closes #132 

# 👨‍💻 Changes proposed(What did you do ?)

Created a button titled as `Stop` in `BuddyMatcher.jsx` which is a link to `/` and redirects you to home on click. Since, there is an effect with the callback that closes the socket and does necessary steps when component unmounts. Therefore, I need not worry about the same when redirecting to `/` with react-router.

# ✔️ Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

# 📷 Screenshots
<img width="1431" alt="image" src="https://user-images.githubusercontent.com/33062947/197932843-51e18291-1d73-4910-b629-d525f107185f.png">