### PR TITLE
feat: added theme switcher in settings

### DIFF
--- a/client/src/context/AppContext.jsx
+++ b/client/src/context/AppContext.jsx
@@ -8,6 +8,7 @@ const initialState = {
     settings: {
         notificationsEnabled: true,
         notificationVolume: 10,
+        theme: true // Sets to dark theme by default on init
     },
     tmpSettings: null,
     currentChatId: null,

--- a/client/src/hooks/useAppTheme.ts
+++ b/client/src/hooks/useAppTheme.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+
+export const DARK_THEME = 'dark'
+export const LIGHT_THEME = 'light'
+
+const useAppTheme = () => {
+  const [theme, setTheme] = useState(localStorage.getItem('theme') || DARK_THEME)
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme)
+  }, [theme])
+
+  const toggleTheme = () => {
+    setTheme((prevState) => {
+        const theme = prevState === DARK_THEME ? LIGHT_THEME : DARK_THEME
+        localStorage.setItem('theme', theme)
+        return theme
+    })
+  }
+
+  const setDarkTheme = () => {
+    localStorage.setItem('theme', 'dark')
+    setTheme('dark')
+  }
+
+  const setLightTheme = () => {
+    localStorage.setItem('theme', 'light')
+    setTheme('light')
+  }
+
+  return { activeTheme: theme, toggleTheme, setDarkTheme, setLightTheme }
+}
+
+export default useAppTheme

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -8,11 +8,14 @@ import {
     Form,
     Message,
     Slider,
+    Toggle
 } from 'rsuite';
 
 import { useApp } from 'src/context/AppContext';
+import useAppTheme from 'src/hooks/useAppTheme';
 
 const Searching = () => {
+    const { setLightTheme, setDarkTheme } = useAppTheme()
     const {
         app,
         hasUnsavedSettings,
@@ -32,6 +35,8 @@ const Searching = () => {
      */
     const handleSubmit = () => {
         updateSettings();
+        if (settings.theme) { setDarkTheme() }
+        else { setLightTheme() }
     };
 
     const handleChange = (newSettings) => {
@@ -72,6 +77,15 @@ const Searching = () => {
                     <Form.HelpText tooltip>
                         Set the volume level for all your notifications
                     </Form.HelpText>
+                </Form.Group>
+                <Form.Group controlId="theme">
+                    <Form.ControlLabel>
+                        Dark Theme 
+                        <Form.HelpText tooltip>
+                            Toggle Dark/Light Theme
+                        </Form.HelpText>
+                    </Form.ControlLabel>
+                    <Form.Control value={settings.theme} accepter={Toggle} name="theme" checked={settings.theme} />
                 </Form.Group>
                 <Form.Group>
                     <ButtonToolbar className="flex justify-end">

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -2,6 +2,30 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+    /* active default dark mode */
+    :root {
+        --primary: 207deg 95% 8%;
+        --secondary: 206deg 44% 15%;
+        --highlight: 35deg 100% 55%;
+        --red: 356deg 100% 61%;
+    }
+
+    :root[data-theme="dark"] {
+        --primary: 207deg 95% 8%;
+        --secondary: 206deg 44% 15%;
+        --highlight: 35deg 100% 55%;
+        --red: 356deg 100% 61%;
+    }
+
+    :root[data-theme="light"] {
+        --primary: 207deg 95% 60%;
+        --secondary: 206deg 70% 45%;
+        --highlight: 35deg 100% 55%;
+        --red: 356deg 100% 61%;
+    }
+}
+
 body {
     margin: 0;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+    darkMode: "class",
     content: ['./src/**/*.{js,jsx,ts,tsx}'],
     theme: {
         extend: {
@@ -6,10 +7,10 @@ module.exports = {
                 mdl: { max: '768px' },
             },
             colors: {
-                primary: '#011627',
-                secondary: '#162938',
-                highlight: '#FF9F1C',
-                red: '#FF3A46',
+                primary: 'hsl(var(--primary) / <alpha-value>)',
+                secondary: 'hsl(var(--secondary) / <alpha-value>)',
+                highlight: 'hsl(var(--highlight) / <alpha-value>)',
+                red: 'hsl(var(--red) / <alpha-value>)',
             },
         },
     },


### PR DESCRIPTION
# Fixes Issue

**My PR closes #268**

# 👨‍💻 Changes proposed(What did you do ?)
Added a theme toggle switch on `/settings` page.
Using css variables we can easily switch the theme.
By default the app sets to dark mode (no changes there)
I have introduced `useAppTheme` hook which will have the logic for changing the theme.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [] My code follows the code style of this project.
- [] This PR does not contain plagiarized content.
- [] The title and description of the PR is clear and explains the approach.

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots

<!-- Add all the screenshots which support your changes -->
![Screenshot 2023-09-17 at 3 59 50 PM](https://github.com/Dun-sin/Whisper/assets/64732692/37a5cbb2-44e1-414f-911c-037fb2bf7c4b)
