### PR TITLE
fix: Resolve issue with double menu on receiving message

### DIFF
--- a/client/src/components/Chat.jsx
+++ b/client/src/components/Chat.jsx
@@ -505,28 +505,6 @@ const Chat = () => {
                                                     >
                                                         <Dropdown.Item
                                                             onClick={() =>
-                                                                handleDelete(id)
-                                                            }
-                                                        >
-                                                            Delete
-                                                        </Dropdown.Item>
-                                                    </Dropdown>
-                                                )}
-                                            {sender.toString() !==
-                                                senderId.toString() &&
-                                                status !== 'pending' && (
-                                                    <Dropdown
-                                                        placement="rightStart"
-                                                        style={{
-                                                            zIndex: 'auto',
-                                                        }}
-                                                        renderToggle={
-                                                            renderIconButtonReceiver
-                                                        }
-                                                        NoCaret
-                                                    >
-                                                        <Dropdown.Item
-                                                            onClick={() =>
                                                                 handleCopyToClipBoard(
                                                                     id
                                                                 )


### PR DESCRIPTION
# Fixes Issue

**My PR closes #289

# 👨‍💻 Changes proposed(What did you do ?)
<h4> Removed the Delete Option for the receiver</h4> 
<h4>  Removed double menu on receiving message</h4>  

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[ X ] - Correct; marked as done
[ X ] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

-  [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots

<!-- Add all the screenshots which support your changes -->
<h2> View For Removed Double Menus </h2>

![image](https://github.com/Dun-sin/Whisper/assets/64489317/4e943482-dbc9-4e9f-8145-0a4ce94db8ab)

<h2>View For Removed Delete option for Receiver</h2>

![image](https://github.com/Dun-sin/Whisper/assets/64489317/c592f2c0-d83c-4d89-90bb-db8a3e8edddd)



