### PR TITLE
fix: Error in parsing messages containing bad words

### DIFF
--- a/client/src/components/Chat.jsx
+++ b/client/src/components/Chat.jsx
@@ -436,11 +436,9 @@ const Chat = () => {
                                                 'justify-between'
                                                 }`}
                                         >
-
-                                            <span
+                                            {typeof message === 'string' ? <span
                                                 dangerouslySetInnerHTML={{ __html: md.render(message) }}
-                                            />
-
+                                            /> : message}
 
                                             {sender.toString() ===
                                                 senderId.toString() &&


### PR DESCRIPTION
# Fixes: Error in parsing messages containing bad words

**My PR closes #320**

# 👨‍💻 Changes proposed
- The **warningMessage** function returns JSX element which markdownIt could not parse. So just added a check condition.

# ✔️ Check List (Check all the applicable boxes)

- [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title and description of the PR is clear and explains the approach.

# 📷 Screenshots

![Screenshot 2023-09-28 204040](https://github.com/Dun-sin/Whisper/assets/76198333/26b13ac6-20ca-4dba-a1f3-c79b9eca7c16)
![Screenshot 2023-09-28 204056](https://github.com/Dun-sin/Whisper/assets/76198333/4d2f6cf9-e697-45c6-a4cb-1ce88e22a407)
