### PR TITLE
fix: Mongodb path issues not able to detect .env file solved

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,5 @@
-require('dotenv').config();
+const path = require("path");
+require("dotenv").config({ path: path.join(__dirname, ".env_sample") });
 
 const express = require('express');
 const app = express();


### PR DESCRIPTION
#371  I have fixed the The `uri` parameter to `openUri()` must be a string, got "undefined". Make sure the first parameter to `mongoose.connect() in Local development also helpful in production build

![Screenshot_3](https://github.com/Dun-sin/Whisper/assets/31253617/1a39e603-406f-46ac-9ad5-db50d536f447)
