### PR TITLE
fix: Flashing Warning Popup Issue

### DIFF
--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -166,6 +166,7 @@ const Searching = () => {
                     </Form.Group>
                     <Divider className="border border-slate-800 my-7"></Divider>
                     <Form.Group>
+                        {hasUnsavedSettings && (
                         <Animation.Bounce in={hasUnsavedSettings}>
                             <div className="w-[100%] flex justify-end mb-3.5 text-xs items-center">
                                 <Icon
@@ -177,6 +178,7 @@ const Searching = () => {
                                 <p className="dark:text-highlight text-red text-lg">Warning: You have unsaved settings</p>
                             </div>
                         </Animation.Bounce>
+                        )}
                         <ButtonToolbar className="flex justify-end">
                             <Animation.Fade in={hasUnsavedSettings}>
                                 <Button


### PR DESCRIPTION
# Fixes Issue #450 

**My PR closes #450**

# 👨‍💻 Changes proposed(What did you do ?)
I have modified the code to ensure that the warning is displayed only when there are actual unsaved changes in the settings. This improves the user experience by preventing the warning from flashing unnecessarily.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

# 📷 Screenshots

_After the fix:_

https://github.com/Dun-sin/Whisper/assets/110025628/de7372fc-a3c3-42e0-a754-951e17792694

<!-- Add all the screenshots which support your changes -->
##  Note to reviewers

Kindly label it as `hacktoberfest-accepted`. Thanks!