### PR TITLE
fix: 'Unsaved Settings Warning' pops up for no reason #450

### DIFF
--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -177,7 +177,6 @@ const Searching = () => {
                                 <p className="dark:text-highlight text-red text-lg">Warning: You have unsaved settings</p>
                             </div>
                         </Animation.Bounce>}
-
                         <ButtonToolbar className="flex justify-end">
                             <Animation.Fade in={hasUnsavedSettings}>
                                 <Button

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -166,7 +166,7 @@ const Searching = () => {
                     </Form.Group>
                     <Divider className="border border-slate-800 my-7"></Divider>
                     <Form.Group>
-                        <Animation.Bounce in={hasUnsavedSettings}>
+                        {hasUnsavedSettings && <Animation.Bounce in={hasUnsavedSettings}>
                             <div className="w-[100%] flex justify-end mb-3.5 text-xs items-center">
                                 <Icon
                                     className='text-highlight'
@@ -176,7 +176,8 @@ const Searching = () => {
                                 />
                                 <p className="dark:text-highlight text-red text-lg">Warning: You have unsaved settings</p>
                             </div>
-                        </Animation.Bounce>
+                        </Animation.Bounce>}
+
                         <ButtonToolbar className="flex justify-end">
                             <Animation.Fade in={hasUnsavedSettings}>
                                 <Button


### PR DESCRIPTION
# Fixes Issue

**My PR closes #450 **

# 👨‍💻 Changes proposed(What did you do ?)

I modified the code to ensure that warning message is displayed only when there are actual unsaved changes by checking 
 `hasUnsavedSettings`. 

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots

<!-- Add all the screenshots which support your changes -->

<details> <summary> After Fix Evidence </summary>

https://github.com/Dun-sin/Whisper/assets/98248371/bfc8fb40-9630-4dd9-ae07-065c1be4c5f3

</details>

<details> <summary>Code Changes</summary> 

<img width="1439" alt="image" src="https://github.com/Dun-sin/Whisper/assets/98248371/a092606a-c036-4686-917d-d1acfe1ffd04">

</details>