### PR TITLE
fix: 'Unsaved Settings Warning' pops up for no reason #450

### DIFF
--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -171,7 +171,7 @@ const Searching = () => {
 					</Form.Group>
 					<Divider className="border border-gray-500 my-2 sm:my-4 md:my-7"></Divider>
 					<Form.Group>
-						<Animation.Bounce in={hasUnsavedSettings}>
+						{hasUnsavedSettings && <Animation.Bounce in={hasUnsavedSettings}>
 							<div className="w-[100%] flex justify-end mb-3.5 text-xs items-center">
 								<Icon
 									className="text-highlight"
@@ -183,7 +183,7 @@ const Searching = () => {
 									Warning: You have unsaved settings
 								</p>
 							</div>
-						</Animation.Bounce>
+						</Animation.Bounce>}
 						<ButtonToolbar className="flex md:justify-end justify-center">
 							<Animation.Fade in={hasUnsavedSettings}>
 								<Button


### PR DESCRIPTION
# Fixes Issue

**My PR closes #450 **

# 👨‍💻 Changes proposed(What did you do ?)

I modified the code to ensure that warning message is displayed only when there are actual unsaved changes by checking 
 `hasUnsavedSettings`. 

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots

<!-- Add all the screenshots which support your changes -->

<details> <summary> Before Fix Evidence </summary>

https://github.com/Dun-sin/Whisper/assets/98248371/19f483f1-984c-49e4-a59d-a600c84cedd1

</details>

<details> <summary> After Fix Evidence </summary>

https://github.com/Dun-sin/Whisper/assets/98248371/65a961cd-21ec-4a47-8756-db21aca40c4c

</details>

<details> <summary>Code Changes</summary> 

<img width="1439" alt="image" src="https://github.com/Dun-sin/Whisper/assets/98248371/bdb54e8a-8c7c-4acd-9762-067a47fd3ca6">

</details>
