### PR TITLE
fix: add display shortcut to send message

### DIFF
--- a/client/src/components/Chat.jsx
+++ b/client/src/components/Chat.jsx
@@ -233,11 +233,11 @@ const Chat = () => {
         if (message === '' || senderId === undefined || senderId === '123456') {
             return;
         }
-        
+
         if (isQuoteReply && message.trim() === quoteMessage.trim()) {
             return;
         }
-        
+
 
         setIsQuoteReply(false)
         setQuoteMessage(null)
@@ -275,10 +275,10 @@ const Chat = () => {
         }
 
         if (inputRef.current) {
-					inputRef.current.value = ''; 
-					setMessage(''); 
-					inputRef.current.focus();
-				}
+            inputRef.current.value = '';
+            setMessage('');
+            inputRef.current.focus();
+        }
     };
 
     // Define a new function to handle "Ctrl + Enter" key press
@@ -340,15 +340,15 @@ const Chat = () => {
 
     const adjustTextareaHeight = () => {
         if (inputRef.current) {
-          const minTextareaHeight = '45px';
-          const currentScrollHeight = inputRef.current.scrollHeight + 'px';
-          
-          inputRef.current.style.height = Math.max(
-            parseInt(minTextareaHeight),
-            parseInt(currentScrollHeight)
-          ) + 'px';
+            const minTextareaHeight = '45px';
+            const currentScrollHeight = inputRef.current.scrollHeight + 'px';
+
+            inputRef.current.style.height = Math.max(
+                parseInt(minTextareaHeight),
+                parseInt(currentScrollHeight)
+            ) + 'px';
         }
-      };
+    };
 
     const handleTypingStatus = throttle((e) => {
         if (e.target.value.length > 0) {
@@ -449,14 +449,14 @@ const Chat = () => {
         }
     };
 
-    useEffect(()=>{
+    useEffect(() => {
         const newLastMessageTime = sortedMessages.filter((message) => message.senderId !== senderId).pop()?.time;
-        if(newLastMessageTime !== lastMessageTime){
+        if (newLastMessageTime !== lastMessageTime) {
             setLastMessageTime(newLastMessageTime);
             clearTimeout(inactiveTimeOut);
-            inactiveTimeOut = setTimeout(checkPartnerResponse,inactiveTimeThreshold);
+            inactiveTimeOut = setTimeout(checkPartnerResponse, inactiveTimeThreshold);
         }
-    },[sortedMessages])
+    }, [sortedMessages])
 
 
     return (
@@ -617,13 +617,16 @@ const Chat = () => {
                 onSubmit={handleSubmit}
             >
                 <div className="w-full flex items-center justify-between bg-secondary rounded-l-md max-h-[150px] relative">
-                    <textarea
-                        placeholder="Send a Message....."
-                        className="h-[45px] focus:outline-none w-[96%] bg-secondary text-white rounded-[15px] resize-none pl-[22px] pr-[22px] py-[10px] text-[18px] placeholder-shown:align-middle min-h-[40px] max-h-[100px] overflow-y-scroll"
-                        ref={inputRef}
-                        value={message}
-                        onChange={handleTypingStatus}
-                    />
+                    <div className='w-full'>
+                        <textarea
+                            placeholder="Send a Message....."
+                            className="h-[45px] focus:outline-none w-[96%] bg-secondary text-white rounded-[15px] resize-none pl-[22px] pr-[22px] py-[10px] text-[18px] placeholder-shown:align-middle min-h-[40px] max-h-[100px] overflow-y-scroll"
+                            ref={inputRef}
+                            value={message}
+                            onChange={handleTypingStatus}
+                        />
+                        <p className='pl-6 pb-1' >Click Ctrl + Enter to Send</p>
+                    </div>
                     <EmojiPicker
                         onEmojiPick={setMessage}
                         focusInput={() => inputRef.current.focus()}


### PR DESCRIPTION
# Fixes Issue

**My PR closes #419**

# 👨‍💻 Changes proposed(What did you do ?)
         Added the shortcut instruction (Press Ctrl+Enter to Send) to send message to avoid confusion among the user.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->
       Added a paragaph tag to put the instruction (Press Ctrl+Enter to send) in the Chat.jsx component at line 628.
# 📷 Screenshots
![Screenshot 2023-10-17 200731](https://github.com/Dun-sin/Whisper/assets/94233772/899f2e83-8946-4ef3-aa8f-2e7cac6134f8)

<!-- Add all the screenshots which support your changes -->
