### PR TITLE
docs: remove highlighting from text in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This app is developed to make chatting much private and easy without stealing yo
    <tbody>
       <tr>
      <td align="Center" width="30%">   
-<a href="https://socket.io/" target="_blank" rel="noreferrer"><img src="https://w7.pngwing.com/pngs/162/702/png-transparent-socket-io-node-js-express-js-npm-network-socket-github-angle-triangle-logo-thumbnail.png" width="36" height="36" alt="SocketIo">
+<a href="https://socket.io/" target="_blank" rel="noreferrer"><img src="https://w7.pngwing.com/pngs/162/702/png-transparent-socket-io-node-js-express-js-npm-network-socket-github-angle-triangle-logo-thumbnail.png" width="36" height="36" alt="SocketIo"></a>
      <br>SocketIo
     </td>  
   <td align="Center" width="30%">


### PR DESCRIPTION
Added a </a> closing tag after the img for SocketIo in README.md

# Fixes #500

**My PR closes Issue #500**

# 👨‍💻 Changes proposed(What did you do ?)

Add a  '\</a\>' closing tag after '\<img\>' for SocketIo in README.md

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title and description of the PR is clear and explains the approach.

# 📷 Screenshots

<!-- Add all the screenshots which support your changes -->
**Before:**
![before](https://github.com/priyavratamohan/Whisper/assets/91372958/bca750d1-de7a-46a2-9cfd-b2ea731d0d7b)
**After:**
![after](https://github.com/priyavratamohan/Whisper/assets/91372958/8e759d98-865e-4038-ad31-18e749ac7087)
