### PR TITLE
chore: remove nav proptype (#670)

### DIFF
--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
-import PropTypes from 'prop-types';
 
 import { Tooltip, Whisper } from 'rsuite';
 import { Icon } from '@iconify/react';
@@ -156,10 +155,6 @@ const NavBar = () => {
 			</div>
 		</div>
 	);
-};
-
-NavBar.propTypes = {
-	className: PropTypes.string,
 };
 
 export default NavBar;


### PR DESCRIPTION
# Fixes Issue

**My PR closes #670**

# 👨‍💻 Changes proposed(What did you do ?)

Removed propTypes from NavBar.jsx.

The following two pieces of code have been removed:

```js
import PropTypes from 'prop-types';
```
and
```js
NavBar.propTypes = { 
 	className: PropTypes.string, 
 }; 
```

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

Removed import for proptypes.

# 📷 Screenshots

<!-- Add all the screenshots which support your changes -->
