### PR TITLE
fix: seen message text in light mode

### DIFF
--- a/client/src/components/Chat/MessageSeen.jsx
+++ b/client/src/components/Chat/MessageSeen.jsx
@@ -51,7 +51,13 @@ const MessageSeen = ({ isRead, isSender }) => {
 		};
 	}, [sortedMessages, isTabVisible, observer]);
 
-	return isSender && <p className="text-sm">{isRead ? 'Seen' : 'Not Seen'}</p>;
+	return (
+    isSender && (
+      <p className="text-sm dark:text-white text-primary">
+        {isRead ? 'Seen' : 'Not Seen'}
+      </p>
+    )
+  );
 };
 
 export default MessageSeen;


### PR DESCRIPTION
# Fixes Issue

My PR closes #678 

# 👨‍💻 Changes proposed(What did you do ?)

Added Tailwind to the <p> tag that holds the seen or not seen message text.
I added `dark:text-white text-primary`

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots

<img width="240" alt="Screenshot 2024-08-22 at 12 44 08 PM" src="https://github.com/user-attachments/assets/de34fa42-0414-46f5-81ce-fc945918f64c">

<img width="192" alt="Screenshot 2024-08-22 at 12 44 34 PM" src="https://github.com/user-attachments/assets/46b468db-2328-4953-8c88-819ff688dec3">