### PR TITLE
Fix:Moved menu toggle into it's own component

### DIFF
--- a/client/src/components/Anonymous.jsx
+++ b/client/src/components/Anonymous.jsx
@@ -30,6 +30,7 @@ import useKeyPress, { ShortcutFlags } from 'src/hooks/useKeyPress';
 import useCheckTimePassed from 'src/hooks/useCheckTimePassed';
 import { useAuth } from 'src/context/AuthContext';
 import { api } from 'src/lib/axios';
+import MenuToggle from './MenuToggle';
 
 const centerItems = `flex items-center justify-center`;
 
@@ -153,17 +154,18 @@ const Anonymous = ({
 		socket.timeout(30000).emit(NEW_EVENT_CLOSE, currentChatId, emitClose)
 	};
 
-	const MenuToggle = (props, ref) => {
-		return (
-			<IconButton
-				{...props}
-				ref={ref}
-				icon={<Icon as={BiDotsVerticalRounded} />}
-				appearance="subtle"
-				circle
-			/>
-		);
-	};
+	// const MenuToggle = (props, ref) => {
+	// 	return (
+	// 		<IconButton
+	// 			{...props}
+	// 			ref={ref}
+	// 			icon={<Icon as={BiDotsVerticalRounded} />}
+	// 			appearance="subtle"
+	// 			circle
+	// 		/>
+	// 	);
+	// };
+	<MenuToggle/>
 
 	const handleClose = (autoSearch = false) => {
 		setDialog({

--- a/client/src/components/MenuToggle.jsx
+++ b/client/src/components/MenuToggle.jsx
@@ -1,5 +1,3 @@
-// MenuToggle.jsx
-
 import React from 'react';
 import { IconButton, Icon } from 'your-ui-library';
 import { BiDotsVerticalRounded } from 'react-icons/bi';

--- a/client/src/components/MenuToggle.jsx
+++ b/client/src/components/MenuToggle.jsx
@@ -1,0 +1,19 @@
+// MenuToggle.jsx
+
+import React from 'react';
+import { IconButton, Icon } from 'your-ui-library';
+import { BiDotsVerticalRounded } from 'react-icons/bi';
+
+const MenuToggle = React.forwardRef((props, ref) => {
+   return (
+      <IconButton
+         {...props}
+         ref={ref}
+         icon={<Icon as={BiDotsVerticalRounded} />}
+         appearance="subtle"
+         circle
+      />
+   );
+});
+
+export default MenuToggle;


### PR DESCRIPTION
# Fixes Issue #660

**My PR closes #issue_number_here**

# 👨‍💻 Changes proposed(What did you do ?)
Moved menu toggle into its own component by creating a component named menu toggle then imported MenuToggle into Anonymous.jsx file and used it there. `<MenuToggle/>`
# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots

<!-- Add all the screenshots which support your changes -->
