### PR TITLE
refactor: move socket emit/on methods to useChatUtils hook

### DIFF
--- a/client/src/components/Chat.jsx
+++ b/client/src/components/Chat.jsx
@@ -259,8 +259,7 @@ const Chat = () => {
 		return decryptedMessages.find((object) => object.id === replyTo);
 	}
 
-	const onNewMessageHandler = useCallback(
-		async (message) => {
+	const onNewMessageHandler = useCallback(async (message) => {
 			try {
 				const decryptedMessage = await decryptMessage(message.message, cryptoKeyRef.current);
 				addMessage(message);
@@ -269,9 +268,7 @@ const Chat = () => {
 			} catch (error) {
 				console.error(`Could not decrypt message: ${error.message}`, error);
 			}
-		},
-		[cryptoKey]
-	);
+		}, [cryptoKey]);
 
 	const onDeleteMessageHandler = useCallback(({ id, chatId }) => {
 		removeMessage(id, chatId);

--- a/client/src/components/Chat.jsx
+++ b/client/src/components/Chat.jsx
@@ -1,14 +1,7 @@
 /* eslint-disable max-len */
 
 import { BsArrow90DegLeft, BsArrow90DegRight } from 'react-icons/bs';
-import {
-	NEW_EVENT_DELETE_MESSAGE,
-	NEW_EVENT_EDIT_MESSAGE,
-	NEW_EVENT_READ_MESSAGE,
-	NEW_EVENT_RECEIVE_MESSAGE,
-	NEW_EVENT_SEND_FAILED,
-	NEW_EVENT_TYPING,
-} from '../../../constants.json';
+
 import chatHelper, {
 	adjustTextareaHeight,
 	arrayBufferToBase64,
@@ -78,7 +71,7 @@ const Chat = () => {
 	const { authState, dispatchAuth } = useAuth();
 	const { logout } = useKindeAuth();
 
-	const { sendMessage, editMessage } = useChatUtils(socket);
+	const { sendMessage, editMessage, emitTyping, setupSocketListeners } = useChatUtils(socket);
 	const { getMessage, handleResend, scrollToMessage } = chatHelper(state, app);
 
 	const inputRef = useRef('');
@@ -102,14 +95,10 @@ const Chat = () => {
 		logout();
 	}
 
-	const emitTyping = useCallback((boolean) => {
-		socket.timeout(5000).emit(NEW_EVENT_TYPING, { chatId: app.currentChatId, isTyping: boolean });
-	}, []);
-
 	const cancelEdit = () => {
 		inputRef.current.value = '';
 		setEditing({ isediting: false, messageID: null });
-		emitTyping(false);
+		emitTyping(app.currentChatId, false);
 	};
 
 	const sortedMessages = useMemo(
@@ -196,7 +185,7 @@ const Chat = () => {
 	const handleSubmit = async (e) => {
 		e.preventDefault();
 
-		emitTyping(false);
+		emitTyping(app.currentChatId, false);
 		const d = new Date();
 		const message = inputRef.current.value.trim(); // Trim the message to remove the extra spaces
 
@@ -242,7 +231,7 @@ const Chat = () => {
 
 	const handleTypingStatus = throttle((e) => {
 		if (e.target.value.length > 0) {
-			emitTyping(true);
+			emitTyping(app.currentChatId, true);
 		}
 		setMessage(e.target.value);
 		adjustTextareaHeight(inputRef);
@@ -271,15 +260,15 @@ const Chat = () => {
 	}
 
 	const onNewMessageHandler = useCallback(async (message) => {
-		try {
-			const decryptedMessage = await decryptMessage(message.message, cryptoKeyRef.current);
-			addMessage(message);
-			playNotification('newMessage');
-			createBrowserNotification('You received a new message on Whisper', decryptedMessage);
-		} catch (error) {
-			console.error(`Could not decrypt message: ${error.message}`, error);
-		}
-	}, [cryptoKey]);
+			try {
+				const decryptedMessage = await decryptMessage(message.message, cryptoKeyRef.current);
+				addMessage(message);
+				playNotification('newMessage');
+				createBrowserNotification('You received a new message on Whisper', decryptedMessage);
+			} catch (error) {
+				console.error(`Could not decrypt message: ${error.message}`, error);
+			}
+		}, [cryptoKey]);
 
 	const onDeleteMessageHandler = useCallback(({ id, chatId }) => {
 		removeMessage(id, chatId);
@@ -297,16 +286,16 @@ const Chat = () => {
 		receiveMessage(messageId, chatId);
 	}, []);
 
-  const onPublicStringHandler = useCallback(({ pemPublicKeyString, pemPrivateKeyString }) => {
-    const pemPublicKeyArrayBuffer = pemToArrayBuffer(pemPublicKeyString);
-    const pemPrivateKeyArrayBuffer = pemToArrayBuffer(pemPrivateKeyString);
+	const onPublicStringHandler = useCallback(({ pemPublicKeyString, pemPrivateKeyString }) => {
+		const pemPublicKeyArrayBuffer = pemToArrayBuffer(pemPublicKeyString);
+		const pemPrivateKeyArrayBuffer = pemToArrayBuffer(pemPrivateKeyString);
 
-    // Import PEM-formatted public key as CryptoKey
-    importKey(pemPublicKeyArrayBuffer, pemPrivateKeyArrayBuffer);
-  }, []);
+		// Import PEM-formatted public key as CryptoKey
+		importKey(pemPublicKeyArrayBuffer, pemPrivateKeyArrayBuffer);
+	}, []);
 
 
-
+	
 	// Clear chat when escape is pressed
 	useEffect(() => {
 		const keyDownHandler = (event) => {
@@ -377,21 +366,16 @@ const Chat = () => {
 
 	useEffect(() => {
 		generateKeyPair();
-		socket.on('publicKey', onPublicStringHandler);
-		socket.on(NEW_EVENT_RECEIVE_MESSAGE, onNewMessageHandler);
-		socket.on(NEW_EVENT_DELETE_MESSAGE, onDeleteMessageHandler);
-		socket.on(NEW_EVENT_EDIT_MESSAGE, onEditMessageHandler);
-		socket.on(NEW_EVENT_READ_MESSAGE, onReadMessageHandler);
-		socket.on(NEW_EVENT_SEND_FAILED, onLimitMessageHandler);
+		const cleanupListeners = setupSocketListeners({
+			onNewMessageHandler,
+			onDeleteMessageHandler,
+			onEditMessageHandler,
+			onReadMessageHandler,
+			onLimitMessageHandler,
+			onPublicStringHandler,
+		});
 
-		return () => {
-			socket.off(NEW_EVENT_RECEIVE_MESSAGE, onNewMessageHandler);
-			socket.off(NEW_EVENT_DELETE_MESSAGE, onDeleteMessageHandler);
-			socket.off(NEW_EVENT_EDIT_MESSAGE, onEditMessageHandler);
-			socket.off(NEW_EVENT_READ_MESSAGE, onReadMessageHandler);
-			socket.off(NEW_EVENT_SEND_FAILED, onLimitMessageHandler);
-			socket.off('publicKey', onPublicStringHandler);
-		};
+		return cleanupListeners;
 	}, []);
 
 	return (

--- a/client/src/components/Chat.jsx
+++ b/client/src/components/Chat.jsx
@@ -98,7 +98,7 @@ const Chat = () => {
 	const cancelEdit = () => {
 		inputRef.current.value = '';
 		setEditing({ isediting: false, messageID: null });
-		emitTyping(app.currentChatId, false);
+		emitTyping({ chatId: app.currentChatId, isTyping: false });
 	};
 
 	const sortedMessages = useMemo(
@@ -185,7 +185,7 @@ const Chat = () => {
 	const handleSubmit = async (e) => {
 		e.preventDefault();
 
-		emitTyping(app.currentChatId, false);
+		emitTyping({ chatId: app.currentChatId, isTyping: false });
 		const d = new Date();
 		const message = inputRef.current.value.trim(); // Trim the message to remove the extra spaces
 
@@ -231,7 +231,7 @@ const Chat = () => {
 
 	const handleTypingStatus = throttle((e) => {
 		if (e.target.value.length > 0) {
-			emitTyping(app.currentChatId, true);
+			emitTyping({ chatId: app.currentChatId, isTyping: true });
 		}
 		setMessage(e.target.value);
 		adjustTextareaHeight(inputRef);
@@ -259,7 +259,8 @@ const Chat = () => {
 		return decryptedMessages.find((object) => object.id === replyTo);
 	}
 
-	const onNewMessageHandler = useCallback(async (message) => {
+	const onNewMessageHandler = useCallback(
+		async (message) => {
 			try {
 				const decryptedMessage = await decryptMessage(message.message, cryptoKeyRef.current);
 				addMessage(message);
@@ -268,7 +269,9 @@ const Chat = () => {
 			} catch (error) {
 				console.error(`Could not decrypt message: ${error.message}`, error);
 			}
-		}, [cryptoKey]);
+		},
+		[cryptoKey]
+	);
 
 	const onDeleteMessageHandler = useCallback(({ id, chatId }) => {
 		removeMessage(id, chatId);
@@ -294,8 +297,6 @@ const Chat = () => {
 		importKey(pemPublicKeyArrayBuffer, pemPrivateKeyArrayBuffer);
 	}, []);
 
-
-	
 	// Clear chat when escape is pressed
 	useEffect(() => {
 		const keyDownHandler = (event) => {

--- a/client/src/lib/chatSocket.js
+++ b/client/src/lib/chatSocket.js
@@ -6,6 +6,9 @@ import {
 	NEW_EVENT_EDIT_MESSAGE,
 	NEW_EVENT_SEND_MESSAGE,
 	NEW_EVENT_READ_MESSAGE,
+	NEW_EVENT_TYPING,
+	NEW_EVENT_RECEIVE_MESSAGE,
+	NEW_EVENT_SEND_FAILED,
 } from '../../../constants.json';
 
 /**
@@ -94,10 +97,57 @@ export default function useChatUtils(socket) {
 				});
 		});
 	}
+
+	function emitTyping({ chatId, isTyping }) {
+		return new Promise((resolve, reject) => {
+			if (!socket.connected) {
+				reject(null);
+				return;
+			}
+			socket
+				.timeout(30000)
+				.emit(NEW_EVENT_TYPING, { chatId, isTyping }, (err, typingStatus) => {
+					if (err) {
+						reject(err);
+						return;
+					}
+
+					resolve(typingStatus);
+			});
+		});
+	}
+
+	function setupSocketListeners({
+		onNewMessageHandler,
+		onDeleteMessageHandler,
+		onEditMessageHandler,
+		onReadMessageHandler,
+		onLimitMessageHandler,
+		onPublicStringHandler,
+	}) {
+		socket.on(NEW_EVENT_RECEIVE_MESSAGE, onNewMessageHandler);
+		socket.on(NEW_EVENT_DELETE_MESSAGE, onDeleteMessageHandler);
+		socket.on(NEW_EVENT_EDIT_MESSAGE, onEditMessageHandler);
+		socket.on(NEW_EVENT_READ_MESSAGE, onReadMessageHandler);
+		socket.on(NEW_EVENT_SEND_FAILED, onLimitMessageHandler);
+		socket.on('publicKey', onPublicStringHandler);
+
+		return () => {
+			socket.off(NEW_EVENT_RECEIVE_MESSAGE, onNewMessageHandler);
+			socket.off(NEW_EVENT_DELETE_MESSAGE, onDeleteMessageHandler);
+			socket.off(NEW_EVENT_EDIT_MESSAGE, onEditMessageHandler);
+			socket.off(NEW_EVENT_READ_MESSAGE, onReadMessageHandler);
+			socket.off(NEW_EVENT_SEND_FAILED, onLimitMessageHandler);
+			socket.off('publicKey', onPublicStringHandler);
+		};
+	}
+
 	return {
 		sendMessage,
 		deleteMessage,
 		editMessage,
 		seenMessage,
+		emitTyping,
+		setupSocketListeners,
 	};
 }


### PR DESCRIPTION
# Fixes Issue

**My PR closes #664**

# 👨‍💻 Changes proposed(What did you do ?)
- Moved all socket-related logic (both `emit` and `on` methods) from the `Chat` component to the `useChatUtils` hook.
- Created a `setupSocketListeners` function in `useChatUtils` to handle all socket event listeners (`NEW_EVENT_RECEIVE_MESSAGE`, `NEW_EVENT_DELETE_MESSAGE`, etc.) and cleanup.
- Updated the `Chat` component to use the refactored methods from `useChatUtils`.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers


<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots

https://github.com/user-attachments/assets/ce4bbf0b-f63c-4a83-842b-2bfb47b09a6a
https://github.com/user-attachments/assets/d409ac3d-e39b-4e1a-a901-cabc6340023b




