### PR TITLE
fix: crash when deleting a message

### DIFF
--- a/client/src/components/Chat/DropDownOption.jsx
+++ b/client/src/components/Chat/DropDownOption.jsx
@@ -42,11 +42,6 @@ const DropDownOptions = ({ id, isSender, inputRef, cancelEdit, setEditing, setRe
 			return;
 		}
 
-		updateMessage(id, {
-			...messageObject,
-			status: 'pending',
-		});
-
 		try {
 			const messageDeleted = await deleteMessage({
 				id,


### PR DESCRIPTION
# Fixes Issue

**My PR closes #704**

# 👨‍💻 Changes proposed(What did you do ?)

- Removed the unnecessary call to `updateMessage` to prevent crashing when deleting a message.
- Updated the function to only call `updateMessage` when needed.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots

https://github.com/user-attachments/assets/bb3729cb-6a99-4818-bacf-bfded97c0c16



<!-- Add all the screenshots which support your changes -->
