### PR TITLE
feat:  add 15-minute restriction on message edit/delete options

### DIFF
--- a/constants.json
+++ b/constants.json
@@ -19,5 +19,7 @@
 	"NEW_EVENT_CREATE_ROOM": "createRoom",
 	"NEW_EVENT_READ_MESSAGE": "read_message",
 	"NEW_EVENT_ONLINE_STATUS": "online_status",
-	"NEW_EVENT_REQUEST_PUBLIC_KEY": "requestPublicKey"
+	"NEW_EVENT_REQUEST_PUBLIC_KEY": "requestPublicKey",
+
+	"FIFTEEN_MINUTES": 900000
 }

--- a/server/sockets/deleteMessage.js
+++ b/server/sockets/deleteMessage.js
@@ -1,5 +1,5 @@
 const { NEW_EVENT_DELETE_MESSAGE } = require('../../constants.json');
-const { getActiveUser, removeMessage } = require('../utils/lib');
+const { getActiveUser, removeMessage, isMessageEditableOrDeletable } = require('../utils/lib');
 
 module.exports = (socket) => {
   socket.on(
@@ -10,6 +10,12 @@ module.exports = (socket) => {
       });
 
       if (!user || !messageId || !chatId) {
+        messageWasDeletedSuccessfully(false);
+        return;
+      }
+
+      // Check if message exists and is within the 15-minute editable window
+      if (!isMessageEditableOrDeletable(chatId, messageId)) {
         messageWasDeletedSuccessfully(false);
         return;
       }

--- a/server/sockets/editMessage.js
+++ b/server/sockets/editMessage.js
@@ -17,6 +17,12 @@ module.exports = (socket) => {
         return;
       }
 
+      // Check if message exists and is within the 15-minute editable window
+      if (!isMessageEditableOrDeletable(chatId, messageId)) {
+        messageWasEditedSuccessfully(false);
+        return;
+      }
+
       const messageEdited = await editMessage(chatId, {
         id: messageId,
         message: newMessage,

--- a/server/utils/lib.js
+++ b/server/utils/lib.js
@@ -8,6 +8,9 @@ const User = require('../models/UserModel');
 const Message = require('../models/MessageModel');
 const { generateObjectId } = require('./helper');
 
+const { FIFTEEN_MINUTES } = require('../../constants.json');
+
+
 /**
  * @typedef {{
  *     id: string,
@@ -532,6 +535,17 @@ async function isUserBlocked(users) {
   }
 }
 
+  function isMessageEditableOrDeletable(chatId, messageId) {
+    const chat = chats[chatId];
+    if (!chat || !chat.messages || !chat.messages[messageId]) {
+        return false; // Message doesn't exist
+    }
+
+    const message = chat.messages[messageId];
+    const timeSinceCreated = Date.now() - new Date(message.time).getTime();
+    return timeSinceCreated <= FIFTEEN_MINUTES; // Check if within 15 minutes
+}
+
 module.exports = {
   init,
   createChat,
@@ -552,5 +566,6 @@ module.exports = {
   delActiveUser,
   seenMessage,
   blockUser,
-  isUserBlocked
+  isUserBlocked,
+  isMessageEditableOrDeletable
 };


### PR DESCRIPTION
# Fixes Issue

**My PR closes #705**

# 👨‍💻 Changes proposed(What did you do ?)
- Added a restriction to prevent users from editing or deleting messages after 15 minutes to promote message integrity.
- Implemented frontend checks to hide edit/delete options if the message is older than 15 minutes.
- Added backend validation to prevent edit/delete requests from bypassing the 15-minute restriction.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots

https://github.com/user-attachments/assets/7163cb53-cf27-47f0-bab8-2fb2a59e5fbb


