### PR TITLE
style: change the span to button for badword element #666

### DIFF
--- a/client/src/components/Chat/BadwordWarning.jsx
+++ b/client/src/components/Chat/BadwordWarning.jsx
@@ -11,15 +11,15 @@ const BadwordWarning = ({ id, setBadwordChoices, badwordChoices }) => {
 	};
 
 	return (
-		<div className="dark:text-white text-black flex flex-col border-red border w-full rounded-r-md p-3">
+		<div className="text-black flex flex-col border-red border w-full rounded-r-md p-3 gap-2">
 			<p>Your buddy is trying to send you a bad word</p>
 			<div className="flex w-full gap-6">
-				<span onClick={() => showBadword(id)} className="text-sm cursor-pointer">
+				<button onClick={() => showBadword(id)} className="hover:bg-primary hover:text-white border border-primary px-4 py-1 rounded-lg text-primary">
 					See
-				</span>
-				<span onClick={() => hideBadword(id)} className="text-red text-sm cursor-pointer">
+				</button>
+				<button onClick={() => hideBadword(id)} className="hover:bg-red hover:text-white border border-red px-4 py-1 rounded-lg text-red">
 					Hide
-				</span>
+				</button>
 			</div>
 		</div>
 	);

--- a/client/src/components/Chat/BadwordWarning.jsx
+++ b/client/src/components/Chat/BadwordWarning.jsx
@@ -11,7 +11,7 @@ const BadwordWarning = ({ id, setBadwordChoices, badwordChoices }) => {
 	};
 
 	return (
-		<div className="text-black flex flex-col border-red border w-full rounded-r-md p-3 gap-2">
+		<div className="dark:text-white text-black flex flex-col border-red border w-full rounded-r-md p-3 gap-2">
 			<p>Your buddy is trying to send you a bad word</p>
 			<div className="flex w-full gap-6">
 				<button onClick={() => showBadword(id)} className="hover:bg-primary hover:text-white border border-primary px-4 py-1 rounded-lg text-primary">

--- a/client/src/components/Chat/BadwordWarning.jsx
+++ b/client/src/components/Chat/BadwordWarning.jsx
@@ -11,13 +11,13 @@ const BadwordWarning = ({ id, setBadwordChoices, badwordChoices }) => {
 	};
 
 	return (
-		<div className="dark:text-white text-black flex flex-col border-red border w-full rounded-r-md p-3 gap-2">
+		<div className="dark:text-white text-black flex flex-col border-red border w-full rounded-r-md p-3">
 			<p>Your buddy is trying to send you a bad word</p>
 			<div className="flex w-full gap-6">
-				<button onClick={() => showBadword(id)} className="hover:bg-primary hover:text-white border border-primary px-4 py-1 rounded-lg text-primary">
+				<button onClick={() => showBadword(id)} className="text-sm">
 					See
 				</button>
-				<button onClick={() => hideBadword(id)} className="hover:bg-red hover:text-white border border-red px-4 py-1 rounded-lg text-red">
+				<button onClick={() => hideBadword(id)} className="text-red text-sm">
 					Hide
 				</button>
 			</div>


### PR DESCRIPTION
**My PR closes #666 **

# 👨‍💻 Changes proposed(What did you do ?)
<img width="1520" alt="image" src="https://github.com/user-attachments/assets/3509331d-9dbc-49bd-bec4-1c2abab0cac8">
Did few changes:

1. Replaced span with button.
2. Added some styling to button and on hover button.
3. Added a gap between the text and button.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots

<!-- Add all the screenshots which support your changes -->
Normal : <br>
<img width="307" alt="image" src="https://github.com/user-attachments/assets/2ff29919-9854-47c0-b162-2ab9b3063a8a">
<br>
On hover: <br>
<img width="308" alt="image" src="https://github.com/user-attachments/assets/79163a0a-b4a9-49b4-a840-5379ce640932">

