### PR TITLE
feat: add a dialog if User denies notfication permission

### DIFF
--- a/client/src/lib/browserNotification.js
+++ b/client/src/lib/browserNotification.js
@@ -1,11 +1,16 @@
 import BadWordsNext from 'bad-words-next';
 import en from 'bad-words-next/data/en.json';
 
-export const requestBrowserNotificationPermissions = () => {
+export const requestBrowserNotificationPermissions = async () => {
 	if (!('Notification' in window)) {
 		console.log('Browser does not support desktop notification');
 	} else {
-		Notification.requestPermission();
+		const res = await Notification.requestPermission();
+		if (res === 'granted') {
+			return true;
+		} else {
+			return false;
+		}
 	}
 };
 

--- a/client/src/pages/Start.jsx
+++ b/client/src/pages/Start.jsx
@@ -6,6 +6,7 @@ import { requestBrowserNotificationPermissions } from 'src/lib/browserNotificati
 import { useApp } from 'src/context/AppContext';
 import useCloseChat from 'src/hooks/useCloseChat';
 import { useEffect } from 'react';
+import { useDialog } from 'src/context/DialogContext';
 
 const centerElement = 'flex flex-col items-center justify-center';
 
@@ -13,13 +14,42 @@ const Start = () => {
 	const { app } = useApp();
 	const navigate = useNavigate();
 	const { handleClose } = useCloseChat();
+	const { setDialog } = useDialog();
 
+	const requestPermission = async () => {
+		try {
+			const isGranted = await requestBrowserNotificationPermissions();
+			if (!isGranted) {
+				setDialog({
+					isOpen: true,
+					text: "We noticed you've blocked Whisper from sending notifications. Are you sure you don’t want to enable them? Notifications help you stay updated, remember who you're talking to, and ensure you dont miss important messages.",
+					handler: async (response) => {
+						if (response) {
+							await requestBrowserNotificationPermissions();
+							setDialog({ isOpen: false });
+						} else {
+							setDialog({ isOpen: false });
+						}
+					},
+					noBtnText: 'No',
+					yesBtnText: 'Try Again',
+				});
+			}
+
+			return isGranted;
+		} catch (error) {
+			console.error('Error requesting notification permission:', error);
+			return false;
+		}
+	};
 	useEffect(() => {
 		if (app.isSearching) {
 			navigate('/searching');
 		}
-
-		requestBrowserNotificationPermissions();
+		const checkPermission = async () => {
+			await requestPermission();
+		};
+		checkPermission();
 	}, []);
 
 	return (

--- a/client/src/pages/Start.jsx
+++ b/client/src/pages/Start.jsx
@@ -22,7 +22,7 @@ const Start = () => {
 			if (!isGranted) {
 				setDialog({
 					isOpen: true,
-					text: "We noticed you've blocked Whisper from sending notifications. Are you sure you don’t want to enable them? Notifications help you stay updated, remember who you're talking to, and ensure you dont miss important messages.",
+					text: "You've blocked Whisper notifications. Enable them to stay updated, keep track of conversations, and never miss important messages.",
 					handler: async (response) => {
 						if (response) {
 							await requestBrowserNotificationPermissions();


### PR DESCRIPTION
# Fixes Issue

**My PR closes #730 **

# 👨‍💻 Changes proposed(What did you do ?) 
Changed the response of notification trigger function . Added a dialog if the user denies the permission . 

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

I would suggest to first show the dialog and then request for permission . 

# 📷 Screenshots
![Screenshot 2024-12-11 234751](https://github.com/user-attachments/assets/fef7ef54-9ea4-4175-9817-1e4fed884b48)
![Screenshot 2024-12-11 234809](https://github.com/user-attachments/assets/b426bdf7-c94d-413b-ba01-6255d4596af7)

<!-- Add all the screenshots which support your changes -->
