### PR TITLE
fix: add height 100% to resolve tab alignment issue

### DIFF
--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -73,7 +73,7 @@ const NavBar = () => {
 			<div className="hidden md:flex">
 				<img src="favicon.ico" />
 			</div>
-			<div className="justify-between md:justify-center flex items-center md:flex-col flex-row w-full gap-2 flex-nowrap overflow-auto">
+			<div className="justify-between md:justify-center flex items-center md:flex-col flex-row w-full h-full gap-2 flex-nowrap overflow-auto">
 				<Whisper
 					placement="auto"
 					controlId="control-id-hover"


### PR DESCRIPTION
# Fixes Issue

**My PR closes #739**

# 👨‍💻 Changes proposed(What did you do ?)
Fixed tab alignment issue by setting the height to 100%.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots

<!-- Add all the screenshots which support your changes -->

**Before**
<img width="379" alt="Screenshot 2025-01-14 at 4 40 38 PM" src="https://github.com/user-attachments/assets/62034a4d-afa3-45d0-ba80-365abd51f362" />

**After**
<img width="377" alt="Screenshot 2025-01-14 at 4 40 28 PM" src="https://github.com/user-attachments/assets/db3427e5-2a03-4440-b4b1-cead634582e0" />


