### PR TITLE
feat: add page exit confirmation for active chats (#452)

### DIFF
--- a/client/src/components/BuddyMatcher.jsx
+++ b/client/src/components/BuddyMatcher.jsx
@@ -59,16 +59,6 @@ const BuddyMatcher = () => {
 		};
 	}, []); // Empty dependency array since handleBeforeUnload doesn't depend on props/state
 
-	useEffect(() => {
-		// Add event listener for beforeunload
-		window.addEventListener('beforeunload', handleBeforeUnload);
-
-		return () => {
-			// Cleanup event listener
-			window.removeEventListener('beforeunload', handleBeforeUnload);
-		};
-	}, []);
-
 	async function handleReconnect() {
 		if (socket.connected) {
 			return;

--- a/client/src/components/BuddyMatcher.jsx
+++ b/client/src/components/BuddyMatcher.jsx
@@ -43,6 +43,32 @@ const BuddyMatcher = () => {
 		endSearch();
 	}
 
+	const handleBeforeUnload = (event) => {
+		const message = 'You have an active chat. Are you sure you want to leave?';
+		event.preventDefault();
+		event.returnValue = message;
+		return message; // This is required for modern browsers
+	};
+
+	useEffect(() => {
+		window.addEventListener('beforeunload', handleBeforeUnload);
+
+		// Clean up event listener on component unmount
+		return () => {
+			window.removeEventListener('beforeunload', handleBeforeUnload);
+		};
+	}, []); // Empty dependency array since handleBeforeUnload doesn't depend on props/state
+
+	useEffect(() => {
+		// Add event listener for beforeunload
+		window.addEventListener('beforeunload', handleBeforeUnload);
+
+		return () => {
+			// Cleanup event listener
+			window.removeEventListener('beforeunload', handleBeforeUnload);
+		};
+	}, []);
+
 	async function handleReconnect() {
 		if (socket.connected) {
 			return;


### PR DESCRIPTION
# Fixes Issue #452 

**My PR closes #452 **

# 👨‍💻 Changes proposed(What did you do ?)
Added a warning dialog to alert users before they attempt to close the tab with an active chat.
Implemented the handleBeforeUnload function to handle the beforeunload event, displaying a warning message.
Used the useEffect hook to add the beforeunload event listener when the component mounts and to clean it up when the component unmounts.


# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots

<!-- Add all the screenshots which support your changes -->
