### PR TITLE
fix: removing unused package image-moderation in server

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,7 +14,6 @@
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-rate-limit": "^7.1.1",
-        "image-moderation": "^1.0.6",
         "mailtrap": "^3.4.0",
         "mongodb": "^5.7.0",
         "mongoose": "^7.4.3",
@@ -1512,11 +1511,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/https": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
-      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg=="
-    },
     "node_modules/human-signals": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
@@ -1565,18 +1559,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA=="
-    },
-    "node_modules/image-moderation": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/image-moderation/-/image-moderation-1.0.6.tgz",
-      "integrity": "sha512-lf7IctVDlTdAV9Jr9fgA5cbPBaId4lPfk+vvcrGMRlwEOKWfXRsrhwplG4y1ojIX2F9P32+tfEjW8SyTqLbSZg==",
-      "dependencies": {
-        "https": "^1.0.0"
-      },
-      "engines": {
-        "node": "*",
-        "npm": "*"
-      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",

--- a/server/package.json
+++ b/server/package.json
@@ -25,7 +25,6 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-rate-limit": "^7.1.1",
-    "image-moderation": "^1.0.6",
     "mailtrap": "^3.4.0",
     "mongodb": "^5.7.0",
     "mongoose": "^7.4.3",


### PR DESCRIPTION
# Fixes Issue

**My PR closes #751**

# 👨‍💻 Changes proposed(What did you do ?)
Removing unused package `image-moderation` in the server application that is unreleased

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots
<img width="945" alt="image" src="https://github.com/user-attachments/assets/cdc6d5ea-384f-4227-a0c4-26c2e042a00d" />

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/1c65aacd-5b40-41d1-a8ea-7fe150c68a17" />


<!-- Add all the screenshots which support your changes -->
