### PR TITLE
Handle before unload event for chat mode

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -45,6 +45,23 @@ function App() {
 		updateOnlineStatus(onlineStatus);
 	}, [onlineStatus]);
 
+	 useEffect(() => {
+    const handleBeforeUnload = (event) => {
+      // Check if user is in chat mode (on /founduser route)
+      const isInChat = window.location.pathname === '/founduser';
+      if (isInChat) {
+        event.preventDefault();
+        event.returnValue = '';
+        return '';
+      }
+    };
+    
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
+
 	return (
 		<div className={`flex flex-col-reverse md:flex-row h-screen ${settings.theme && 'dark'}`}>
 			<Toaster position="top-center" reverseOrder={false} />


### PR DESCRIPTION
Add beforeunload event listener to warn users when closing tab during active chat

## Description
This PR implements a warning dialog when users attempt to close the browser tab while actively chatting (on the /founduser route). This prevents accidental data loss and provides a better user experience.

## Changes Proposed
- Added a `beforeunload` event listener in the App component
- The listener checks if the user is on the `/founduser` route (active chat)
- If in chat mode, it prevents the default unload and shows the browser's confirmation dialog
- Properly cleans up the event listener on component unmount

## How to Test
1. Start a chat with another user (navigate to /founduser)
2. Try to close the browser tab or navigate away
3. A browser confirmation dialog should appear
4. Click Cancel to stay in chat, or Leave to close

Fixes issue #452