### PR TITLE
feat: warn before closing tab with an active chat

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -15,6 +15,7 @@ import Start from 'pages/Start';
 import { useApp } from 'src/context/AppContext';
 import { useAuth } from 'context/AuthContext';
 import useIsTabActive from './hooks/useIsTabActive';
+import useWarnBeforeUnload from './hooks/useWarnBeforeUnload';
 import MatchFound from './pages/MatchFound';
 import { Toaster } from 'react-hot-toast';
 
@@ -28,6 +29,8 @@ function App() {
 	const [onlineStatus, setOnlineStatus] = useState(null);
 
 	const isTabActive = useIsTabActive();
+
+	useWarnBeforeUnload(Boolean(app.currentChatId));
 
 	useEffect(() => {
 		if (!isLoggedIn) {

--- a/client/src/hooks/useWarnBeforeUnload.js
+++ b/client/src/hooks/useWarnBeforeUnload.js
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+
+// Warns the user with the browser's native confirmation dialog before they
+// close/refresh the tab while shouldWarn is true (e.g. an active chat exists)
+const useWarnBeforeUnload = (shouldWarn) => {
+	useEffect(() => {
+		if (!shouldWarn) {
+			return;
+		}
+
+		const handleBeforeUnload = (event) => {
+			event.preventDefault();
+			event.returnValue = '';
+		};
+
+		window.addEventListener('beforeunload', handleBeforeUnload);
+
+		return () => {
+			window.removeEventListener('beforeunload', handleBeforeUnload);
+		};
+	}, [shouldWarn]);
+};
+
+export default useWarnBeforeUnload;


### PR DESCRIPTION
## Summary
- Adds a `beforeunload` listener that warns the user via the browser's native confirmation dialog when they try to close/refresh the tab while an active chat exists (`app.currentChatId`)
- Implemented as a reusable hook (`useWarnBeforeUnload`) wired in at the app root (`App.jsx`) rather than a single component, per discussion in the issue
- A fully custom dialog isn't possible on tab close due to browser security restrictions (confirmed in the issue thread), so this uses the native `beforeunload` confirmation as agreed

closes #452

## Test plan
- [x] `npx eslint` clean on changed files
- [x] `npm run build` succeeds
- [ ] Manual: open a chat, attempt to close/refresh the tab, confirm the native "leave site?" prompt appears
- [ ] Manual: with no active chat, confirm no prompt appears on tab close