### PR TITLE
fix: apply theme changes immediately in settings

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -24,7 +24,9 @@ function App() {
 	const { isLoggedIn } = useAuth();
 	const { updateOnlineStatus, app } = useApp();
 
-	const { settings } = app;
+	const settings = app.tmpSettings
+    ? { ...app.settings, ...app.tmpSettings }
+    : app.settings;
 	const [onlineStatus, setOnlineStatus] = useState(null);
 
 	const isTabActive = useIsTabActive();
@@ -46,7 +48,7 @@ function App() {
 	}, [onlineStatus]);
 
 	return (
-		<div className={`flex flex-col-reverse md:flex-row h-screen ${settings.theme && 'dark'}`}>
+		<div className={`flex flex-col-reverse md:flex-row h-screen ${settings.theme ? 'dark' : ''}`}>
 			<Toaster position="top-center" reverseOrder={false} />
 			{isLoggedIn && <NavBar />}
 			<Routes>

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 import { Animation, Button, ButtonToolbar, Divider, Form, Slider, Toggle } from 'rsuite';
 
 import { Icon } from '@iconify/react';
@@ -41,6 +41,11 @@ const Searching = () => {
 	const handleChange = (newSettings) => {
 		updateTmpSettings(newSettings);
 	};
+	useEffect(() => {
+    return () => {
+        cancelSettingsUpdate();
+    };
+}, []);
 
 	return (
 		<div


### PR DESCRIPTION
# Fixes Issue

**My PR closes #790**

# 👨‍💻 Changes proposed(What did you do ?)

- Updated the application theme to use temporary settings when available.
- Theme changes are now applied immediately when the user toggles the theme in Settings.
- The selected theme is still only permanently saved when the user clicks Update.
- Leaving settings page discards the temporary theme change and restores the previously saved theme.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

The icons in light mode are barely visible and the the unsaved setting warning is up even after toggling it back to the saved settings, both can be addressed in two separate PRs. 

# 📷 Screenshots

https://github.com/user-attachments/assets/d2287fe6-3aa9-46cc-984c-c77d161d2312

